### PR TITLE
add wave_action

### DIFF
--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -338,7 +338,7 @@ end
 	kdensity(k,ψ,X,K)
 
 Calculates the angle integrated momentum density ``|\\phi(k)|^2``, at the
-points `k`, with the usual radial weight in `k` space ensuring normalization under ∫dk. Arrays `X`, `K` should be computed using `makearrays`.
+points `k`, with the usual radial weight in `k` space ensuring normalization under ∫dk. Units will be population per wavenumber. Arrays `X`, `K` should be computed using `makearrays`.
 """
 function kdensity(k,psi::Psi{2})  
     @unpack ψ,X,K = psi; 
@@ -351,6 +351,15 @@ function kdensity(k,psi::Psi{3})
 	C = auto_correlate(ψ,X,K)
     return sinc_reduce(k,X...,C)
 end
+
+"""
+	wave_action(k,ψ,X,K)
+
+Calculates the angle integrated wave-action spectrum ``|\\phi(\mathbf{k})|^2``, at the
+points `k`, without the radial weight in `k` space ensuring normalization under ∫dk. Units will be population per wavenumber cubed. Isotropy is not assumed. Arrays `X`, `K` should be computed using `makearrays`.
+"""
+wave_action(k,psi::Psi{2}) = kdensity(k,psi::Psi{2}) ./k 
+wave_action(k,psi::Psi{3}) = kdensity(k,psi::Psi{3})./k^2
 
 """
 	incompressible_spectrum(k,ψ)


### PR DESCRIPTION
add wave action spectrum (angle integrated momentum density), which differs from kdensity by the radial weight in 2d or 3d.