### PR TITLE
Add CUDA checkpoint spectrum analysis path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@
 *.jl.mem
 /Manifest.toml
 /test/Manifest.toml
+/benchmark/Manifest.toml
+/benchmark/outputs/
 /docs/build/
 .DS_Store

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,14 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
+[weakdeps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+
+[extensions]
+QuantumFluidSpectraCUDAExt = "CUDA"
+
 [compat]
+CUDA = ">=5.7, <5.9"
 FFTW = "1, 1.4"
 PaddedViews = "0.5"
 SpecialFunctions = "1, 1.3, 1.4, 2"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+QuantumFluidSpectra = "8ddfec37-9569-48bd-b1f3-d8731767ee3a"
+
+[compat]
+BenchmarkTools = "1"
+CUDA = ">=5.7, <5.9"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,12 @@
+# Checkpoint CPU/GPU Benchmark
+
+This benchmark compares the existing CPU `density_spectrum` + `kinetic_density`
+path with the CUDA checkpoint-analysis path:
+
+```sh
+julia --project=benchmark -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'
+julia --project=benchmark benchmark/checkpoint_cpu_gpu.jl --dim=3 --n=32 --nradial=64 --seconds=10
+```
+
+The benchmark environment keeps CUDA.jl below the CUDA 12-runtime line so it can
+run on Thunderbird nodes with CUDA 11.x drivers.

--- a/benchmark/checkpoint_cpu_gpu.jl
+++ b/benchmark/checkpoint_cpu_gpu.jl
@@ -1,0 +1,94 @@
+using BenchmarkTools
+using CUDA
+using QuantumFluidSpectra
+
+function _arg(name, default)
+    prefix = "--$(name)="
+    for arg in ARGS
+        startswith(arg, prefix) && return split(arg, "=", limit = 2)[2]
+    end
+    return default
+end
+
+function _field_2d(X)
+    x, y = X
+    yr = reshape(y, 1, :)
+    amp = @. 1 + 0.12 * cos(2π * x) + 0.08 * sin(4π * yr)
+    phase = @. 2π * x + 4π * yr + 0.2 * sin(2π * x) * cos(2π * yr)
+    return complex.(amp .* exp.(im .* phase))
+end
+
+function _field_3d(X)
+    x, y, z = X
+    yr = reshape(y, 1, :, 1)
+    zr = reshape(z, 1, 1, :)
+    amp = @. 1 + 0.1 * cos(2π * x) + 0.08 * sin(2π * yr) + 0.06 * cos(2π * zr)
+    phase = @. 2π * x + 2π * yr + 2π * zr + 0.15 * sin(2π * x) * cos(2π * yr)
+    return complex.(amp .* exp.(im .* phase))
+end
+
+function _problem(dim, n, nradial)
+    L = ntuple(_ -> 1.0, dim)
+    N = ntuple(_ -> n, dim)
+    X, K, _, _ = xk_arrays(L, N)
+    ψ = dim == 2 ? _field_2d(X) : _field_3d(X)
+    psi = Psi(ψ, X, K)
+    kmax = maximum(abs, K[1])
+    k = collect(LinRange(0.0, kmax, nradial))
+    return psi, k
+end
+
+function _summary(label, trial)
+    println(label)
+    display(trial)
+    println()
+end
+
+function main()
+    dim = parse(Int, _arg("dim", "3"))
+    n = parse(Int, _arg("n", dim == 2 ? "128" : "32"))
+    nradial = parse(Int, _arg("nradial", "64"))
+    seconds = parse(Float64, _arg("seconds", "10"))
+
+    dim in (2, 3) || error("--dim must be 2 or 3")
+    CUDA.functional() || error("CUDA.functional() is false on this machine")
+
+    println("QuantumFluidSpectra checkpoint CPU/GPU benchmark")
+    println("device: ", CUDA.name(CUDA.device()))
+    println("dim: ", dim, ", n: ", n, ", nradial: ", nradial)
+
+    psi_cpu, k_cpu = _problem(dim, n, nradial)
+    psi_gpu = gpu(psi_cpu)
+    cache = checkpoint_analysis_cache(psi_gpu; k = k_cpu)
+
+    density_cpu = density_spectrum(k_cpu, psi_cpu)
+    kinetic_cpu = kinetic_density(k_cpu, psi_cpu)
+
+    analyze_checkpoint!(cache, psi_gpu)
+    CUDA.synchronize()
+    result_gpu = checkpoint_results(cache; host = true)
+
+    density_err =
+        maximum(abs.(result_gpu.density .- density_cpu)) /
+        max(maximum(abs, density_cpu), eps(real(eltype(density_cpu))))
+    kinetic_err =
+        maximum(abs.(result_gpu.kinetic .- kinetic_cpu)) /
+        max(maximum(abs, kinetic_cpu), eps(real(eltype(kinetic_cpu))))
+    println("density relative max error: ", density_err)
+    println("kinetic relative max error: ", kinetic_err)
+
+    cpu_trial = @benchmark begin
+        density_spectrum($k_cpu, $psi_cpu)
+        kinetic_density($k_cpu, $psi_cpu)
+    end seconds = seconds
+
+    gpu_trial = @benchmark begin
+        analyze_checkpoint!($cache, $psi_gpu)
+        CUDA.synchronize()
+    end seconds = seconds
+
+    _summary("CPU density + kinetic", cpu_trial)
+    _summary("GPU checkpoint density + kinetic", gpu_trial)
+end
+
+main()

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "ext/QuantumFluidSpectraCUDAExt.jl"
+  - "benchmark/**"

--- a/ext/QuantumFluidSpectraCUDAExt.jl
+++ b/ext/QuantumFluidSpectraCUDAExt.jl
@@ -1,0 +1,378 @@
+module QuantumFluidSpectraCUDAExt
+
+using CUDA
+using FFTW
+using QuantumFluidSpectra
+using SpecialFunctions
+
+import QuantumFluidSpectra:
+    Psi,
+    CUDADevice,
+    gpu,
+    cpu,
+    checkpoint_analysis_cache,
+    analyze_checkpoint!,
+    checkpoint_results
+
+const CuVecTuple{D,T} = NTuple{D,CUDA.CuVector{T}}
+
+mutable struct CUDAAnalysisCache{D,T,RT,KT,XT,R}
+    X::XT
+    K::KT
+    k::CUDA.CuVector{RT}
+    DX::NTuple{D,RT}
+    DK::NTuple{D,RT}
+    corr::CUDA.CuArray{T,D}
+    work::CUDA.CuArray{T,D}
+    fftwork::CUDA.CuArray{T,D}
+    partials::CUDA.CuMatrix{RT}
+    radial::R
+    density::CUDA.CuVector{RT}
+    kinetic::CUDA.CuVector{RT}
+    groups::Int
+    chunk::Int
+end
+
+struct RadialWeightCache{I,R,J}
+    rid::I
+    radii::R
+    weights::J
+end
+
+function _require_cuda()
+    CUDA.functional() ||
+        error("CUDA checkpoint analysis requested, but CUDA.functional() is false")
+    return nothing
+end
+
+gpu(psi::Psi) = begin
+    _require_cuda()
+    return Psi(CUDA.CuArray(psi.ψ), map(CUDA.CuArray, psi.X), map(CUDA.CuArray, psi.K))
+end
+
+cpu(psi::Psi) = Psi(Array(psi.ψ), map(Array, psi.X), map(Array, psi.K))
+
+_require_device_array(A) =
+    A isa CUDA.CuArray || error("CUDA checkpoint analysis requires device-resident arrays")
+
+function _require_device_psi(psi::Psi)
+    _require_cuda()
+    _require_device_array(psi.ψ)
+    all(x -> x isa CUDA.CuVector, psi.X) ||
+        error("CUDA checkpoint analysis requires psi.X vectors on device")
+    all(k -> k isa CUDA.CuVector, psi.K) ||
+        error("CUDA checkpoint analysis requires psi.K vectors on device")
+    return nothing
+end
+
+function _grid_metrics(x)
+    xh = Array(x)
+    dx = xh[2] - xh[1]
+    L = xh[end] - xh[begin] + dx
+    return dx, L
+end
+
+function _fft_differentials(X, K)
+    return ntuple(length(X)) do i
+        x = Array(X[i])
+        k = Array(K[i])
+        dx = x[2] - x[1]
+        dk = k[2] - k[1]
+        RT = promote_type(eltype(x), eltype(k))
+        return (RT(dx / sqrt(2π)), RT(length(k) * dk / sqrt(2π)))
+    end
+end
+
+function _default_radial_grid(psi::Psi, nradial)
+    khost = map(Array, psi.K)
+    kmax = maximum(map(k -> maximum(abs, k), khost))
+    RT = real(eltype(psi.ψ))
+    return CUDA.CuArray(collect(RT, LinRange(zero(RT), RT(kmax), nradial)))
+end
+
+function _build_bessel_radius_cache(k, nx::Int, ny::Int, dx, dy)
+    dx ≈ dy || error("Cached CUDA Bessel reduction currently requires equal grid spacing")
+    ix0 = nx ÷ 2
+    iy0 = ny ÷ 2
+    ids = Vector{Int32}(undef, nx * ny)
+    index = Dict{Int,Int32}()
+    RT = real(eltype(k))
+    radii = RT[]
+    next_id = Int32(0)
+    for q = 1:ny, p = 1:nx
+        ix = p - 1 - ix0
+        iy = q - 1 - iy0
+        key = ix * ix + iy * iy
+        id = get(index, key, Int32(0))
+        if id == 0
+            push!(radii, RT(dx * sqrt(key)))
+            next_id += 1
+            id = next_id
+            index[key] = id
+        end
+        ids[p+(q-1)*nx] = id
+    end
+    radii_gpu = CUDA.CuArray(radii)
+    weights = SpecialFunctions.besselj0.(reshape(k, :, 1) .* reshape(radii_gpu, 1, :))
+    return RadialWeightCache(CUDA.CuArray(ids), radii_gpu, weights)
+end
+
+_sinc_weight(kr) = ifelse(abs(kr) > 1.0e-12, sin(kr) / kr, one(kr) - kr * kr / 6)
+
+function _build_sinc_radius_cache(k, nx::Int, ny::Int, nz::Int, dx, dy, dz)
+    (dx ≈ dy && dx ≈ dz) ||
+        error("Cached CUDA sinc reduction currently requires equal grid spacing")
+    ix0 = nx ÷ 2
+    iy0 = ny ÷ 2
+    iz0 = nz ÷ 2
+    ids = Vector{Int32}(undef, nx * ny * nz)
+    index = Dict{Int,Int32}()
+    RT = real(eltype(k))
+    radii = RT[]
+    next_id = Int32(0)
+    for r = 1:nz, q = 1:ny, p = 1:nx
+        ix = p - 1 - ix0
+        iy = q - 1 - iy0
+        iz = r - 1 - iz0
+        key = ix * ix + iy * iy + iz * iz
+        id = get(index, key, Int32(0))
+        if id == 0
+            push!(radii, RT(dx * sqrt(key)))
+            next_id += 1
+            id = next_id
+            index[key] = id
+        end
+        ids[p+(q-1)*nx+(r-1)*nx*ny] = id
+    end
+    radii_gpu = CUDA.CuArray(radii)
+    weights = _sinc_weight.(reshape(k, :, 1) .* reshape(radii_gpu, 1, :))
+    return RadialWeightCache(CUDA.CuArray(ids), radii_gpu, weights)
+end
+
+function checkpoint_analysis_cache(
+    psi::Psi{D};
+    backend = CUDADevice(),
+    k = nothing,
+    nradial = length(psi.K[1]),
+    chunk = 2048,
+) where {D}
+    backend isa CUDADevice ||
+        error("Unsupported checkpoint analysis backend: $(typeof(backend))")
+    D in (2, 3) || error("CUDA checkpoint analysis currently supports 2D and 3D Psi fields")
+    _require_device_psi(psi)
+
+    T = eltype(psi.ψ)
+    RT = real(T)
+    kout = isnothing(k) ? _default_radial_grid(psi, nradial) : CUDA.CuArray(k)
+    padsize = ntuple(i -> 2 * size(psi.ψ, i), D)
+    DXDK = _fft_differentials(psi.X, psi.K)
+    DX = ntuple(i -> RT(DXDK[i][1]), D)
+    DK = ntuple(i -> RT(DXDK[i][2]), D)
+    nlinear = prod(padsize)
+    groups = cld(nlinear, chunk)
+    radial = if D == 2
+        dx = Array(psi.X[1][2:2] .- psi.X[1][1:1])[1]
+        dy = Array(psi.X[2][2:2] .- psi.X[2][1:1])[1]
+        _build_bessel_radius_cache(kout, padsize[1], padsize[2], dx, dy)
+    elseif D == 3
+        dx = Array(psi.X[1][2:2] .- psi.X[1][1:1])[1]
+        dy = Array(psi.X[2][2:2] .- psi.X[2][1:1])[1]
+        dz = Array(psi.X[3][2:2] .- psi.X[3][1:1])[1]
+        _build_sinc_radius_cache(kout, padsize[1], padsize[2], padsize[3], dx, dy, dz)
+    else
+        nothing
+    end
+
+    return CUDAAnalysisCache(
+        psi.X,
+        psi.K,
+        kout,
+        DX,
+        DK,
+        CUDA.zeros(T, padsize),
+        CUDA.zeros(T, padsize),
+        CUDA.zeros(T, padsize),
+        CUDA.zeros(RT, length(kout), groups),
+        radial,
+        CUDA.zeros(RT, length(kout)),
+        CUDA.zeros(RT, length(kout)),
+        groups,
+        chunk,
+    )
+end
+
+function _zeropad!(B, A::CUDA.CuArray{T,D}) where {T,D}
+    S = size(A)
+    any(isodd, S) && error("Array dims not divisible by 2")
+    fill!(B, zero(T))
+    nI = S .÷ 2
+    inner = ntuple(i -> (nI[i]+1):(nI[i]+S[i]), D)
+    copyto!(view(B, inner...), A)
+    return B
+end
+
+function _auto_correlate!(out, ψ, cache::CUDAAnalysisCache{D}) where {D}
+    _zeropad!(out, ψ)
+    work = cache.fftwork
+    dxscale = prod(cache.DX)^2
+    dkscale = prod(cache.DK) * (2π)^(D / 2)
+    work .= fft(out)
+    @. work = abs2(work) * dxscale
+    out .= fftshift(ifft(work) .* dkscale)
+    return out
+end
+
+function _gradient(psi::Psi{1})
+    (; ψ, K) = psi
+    kx = K[1]
+    ϕ = fft(ψ)
+    return ifft(@. im * kx * ϕ)
+end
+
+function _gradient(psi::Psi{2})
+    (; ψ, K) = psi
+    kx, ky = K
+    ϕ = fft(ψ)
+    ψx = ifft(@. im * kx * ϕ)
+    ψy = ifft(@. im * ky' * ϕ)
+    return ψx, ψy
+end
+
+function _gradient(psi::Psi{3})
+    (; ψ, K) = psi
+    kx, ky, kz = K
+    kzr = reshape(kz, 1, 1, length(kz))
+    ϕ = fft(ψ)
+    ψx = ifft(@. im * kx * ϕ)
+    ψy = ifft(@. im * ky' * ϕ)
+    ψz = ifft(@. im * kzr * ϕ)
+    return ψx, ψy, ψz
+end
+
+function _bessel_reduce_cached_kernel!(partials, C, rid, weights, nx, ny, chunk)
+    i = blockIdx().x
+    g = blockIdx().y
+    tid = threadIdx().x
+    stride = blockDim().x
+    start = (g - 1) * chunk + 1
+    stop = min(g * chunk, nx * ny)
+    s = zero(eltype(partials))
+    @inbounds for lin = (start+tid-1):stride:stop
+        s += weights[i, rid[lin]] * real(C[lin])
+    end
+    partials[i, g] = s
+    return nothing
+end
+
+function _sinc_reduce_cached_kernel!(partials, C, rid, weights, nx, ny, nz, chunk)
+    i = blockIdx().x
+    g = blockIdx().y
+    tid = threadIdx().x
+    stride = blockDim().x
+    start = (g - 1) * chunk + 1
+    stop = min(g * chunk, nx * ny * nz)
+    s = zero(eltype(partials))
+    @inbounds for lin = (start+tid-1):stride:stop
+        s += weights[i, rid[lin]] * real(C[lin])
+    end
+    partials[i, g] = s
+    return nothing
+end
+
+function _reduce!(out, cache::CUDAAnalysisCache{2}, C)
+    x, y = cache.X
+    dx, _ = _grid_metrics(x)
+    dy, _ = _grid_metrics(y)
+    nx, ny = size(C)
+    fill!(cache.partials, zero(eltype(cache.partials)))
+    threads = 256
+    groups = cld(nx * ny, cache.chunk)
+    @cuda threads = threads blocks = (length(cache.k), groups) _bessel_reduce_cached_kernel!(
+        cache.partials,
+        C,
+        cache.radial.rid,
+        cache.radial.weights,
+        nx,
+        ny,
+        cache.chunk,
+    )
+    sums = vec(sum(view(cache.partials, :, 1:groups); dims = 2))
+    out .= sums .* cache.k .* (dx * dy / (2π))
+    return out
+end
+
+function _reduce!(out, cache::CUDAAnalysisCache{3}, C)
+    x, y, z = cache.X
+    dx, _ = _grid_metrics(x)
+    dy, _ = _grid_metrics(y)
+    dz, _ = _grid_metrics(z)
+    nx, ny, nz = size(C)
+    fill!(cache.partials, zero(eltype(cache.partials)))
+    threads = 256
+    groups = cld(nx * ny * nz, cache.chunk)
+    @cuda threads = threads blocks = (length(cache.k), groups) _sinc_reduce_cached_kernel!(
+        cache.partials,
+        C,
+        cache.radial.rid,
+        cache.radial.weights,
+        nx,
+        ny,
+        nz,
+        cache.chunk,
+    )
+    sums = vec(sum(view(cache.partials, :, 1:groups); dims = 2))
+    out .= sums .* cache.k .^ 2 .* (dx * dy * dz / (2π^2))
+    return out
+end
+
+function _density_spectrum!(out, cache::CUDAAnalysisCache, psi::Psi)
+    _auto_correlate!(cache.corr, abs2.(psi.ψ), cache)
+    return _reduce!(out, cache, cache.corr)
+end
+
+function _kinetic_density!(out, cache::CUDAAnalysisCache{2}, psi::Psi{2})
+    ψx, ψy = _gradient(psi)
+    _auto_correlate!(cache.corr, ψx, cache)
+    _auto_correlate!(cache.work, ψy, cache)
+    @. cache.corr = 0.5 * (cache.corr + cache.work)
+    return _reduce!(out, cache, cache.corr)
+end
+
+function _kinetic_density!(out, cache::CUDAAnalysisCache{3}, psi::Psi{3})
+    ψx, ψy, ψz = _gradient(psi)
+    _auto_correlate!(cache.corr, ψx, cache)
+    _auto_correlate!(cache.work, ψy, cache)
+    @. cache.corr = cache.corr + cache.work
+    _auto_correlate!(cache.work, ψz, cache)
+    @. cache.corr = 0.5 * (cache.corr + cache.work)
+    return _reduce!(out, cache, cache.corr)
+end
+
+function analyze_checkpoint!(
+    cache::CUDAAnalysisCache,
+    psi::Psi;
+    spectra = (:density, :kinetic),
+)
+    _require_device_psi(psi)
+    psi.X === cache.X || error("Checkpoint cache X vectors do not match psi.X")
+    psi.K === cache.K || error("Checkpoint cache K vectors do not match psi.K")
+    if :density in spectra
+        _density_spectrum!(cache.density, cache, psi)
+    end
+    if :kinetic in spectra
+        _kinetic_density!(cache.kinetic, cache, psi)
+    end
+    return cache
+end
+
+function checkpoint_results(cache::CUDAAnalysisCache; host = false)
+    result = (k = cache.k, density = cache.density, kinetic = cache.kinetic)
+    host || return result
+    return (
+        k = Array(cache.k),
+        density = Array(cache.density),
+        kinetic = Array(cache.kinetic),
+    )
+end
+
+end

--- a/src/QuantumFluidSpectra.jl
+++ b/src/QuantumFluidSpectra.jl
@@ -25,6 +25,7 @@ end
 
 include("arrays.jl")
 include("analysis.jl")
+include("checkpoint_analysis.jl")
 
 export Psi, xvec, kvec, xvecs, kvecs, radial_kgrid
 export auto_correlate, cross_correlate
@@ -39,5 +40,7 @@ export incompressible_density, compressible_density, qpressure_density
 export ic_density, iq_density, cq_density
 export density_spectrum, trap_spectrum
 export gpe_particle_transfer, gpe_particle_flux
+export CUDADevice,
+    gpu, cpu, checkpoint_analysis_cache, analyze_checkpoint!, checkpoint_results
 
 end

--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -319,6 +319,9 @@ cross_correlate(psi1::Psi{D}, psi2::Psi{D}) where {D} =
     cross_correlate(psi1.ψ, psi2.ψ, psi1.X, psi1.K)
 
 function bessel_reduce(k, x, y, C)
+    cached = _cached_bessel_reduce(k, x, y, C)
+    !isnothing(cached) && return cached
+
     dx, dy = x[2] - x[1], y[2] - y[1]
     Nx, Ny = 2 * length(x), 2 * length(y)
     Lx = x[end] - x[begin] + dx
@@ -375,7 +378,100 @@ function _integrated_sinc_kernel(k, r)
     end
 end
 
+function _cached_radial_ids_2d(x, y)
+    dx, dy = x[2] - x[1], y[2] - y[1]
+    isapprox(dx, dy; rtol = sqrt(eps(float(real(dx))))) || return nothing
+    Nx, Ny = 2 * length(x), 2 * length(y)
+    px0, py0 = Nx ÷ 2, Ny ÷ 2
+    ids = Array{Int32}(undef, Nx, Ny)
+    index = Dict{Int,Int32}()
+    RT = typeof(float(real(dx)))
+    radii = RT[]
+    next_id = Int32(0)
+    for q = 1:Ny, p = 1:Nx
+        ix = p - 1 - px0
+        iy = q - 1 - py0
+        key = ix * ix + iy * iy
+        id = get(index, key, Int32(0))
+        if id == 0
+            push!(radii, RT(dx * sqrt(key)))
+            next_id += 1
+            id = next_id
+            index[key] = id
+        end
+        ids[p, q] = id
+    end
+    return ids, radii, dx, dy
+end
+
+function _cached_radial_ids_3d(x, y, z)
+    dx, dy, dz = x[2] - x[1], y[2] - y[1], z[2] - z[1]
+    tol = sqrt(eps(float(real(dx))))
+    (isapprox(dx, dy; rtol = tol) && isapprox(dx, dz; rtol = tol)) || return nothing
+    Nx, Ny, Nz = 2 * length(x), 2 * length(y), 2 * length(z)
+    px0, py0, pz0 = Nx ÷ 2, Ny ÷ 2, Nz ÷ 2
+    ids = Array{Int32}(undef, Nx, Ny, Nz)
+    index = Dict{Int,Int32}()
+    RT = typeof(float(real(dx)))
+    radii = RT[]
+    next_id = Int32(0)
+    for r = 1:Nz, q = 1:Ny, p = 1:Nx
+        ix = p - 1 - px0
+        iy = q - 1 - py0
+        iz = r - 1 - pz0
+        key = ix * ix + iy * iy + iz * iz
+        id = get(index, key, Int32(0))
+        if id == 0
+            push!(radii, RT(dx * sqrt(key)))
+            next_id += 1
+            id = next_id
+            index[key] = id
+        end
+        ids[p, q, r] = id
+    end
+    return ids, radii, dx, dy, dz
+end
+
+function _cached_bessel_reduce(k, x, y, C)
+    cache = _cached_radial_ids_2d(x, y)
+    isnothing(cache) && return nothing
+    ids, radii, dx, dy = cache
+    weights = besselj0.(reshape(k, :, 1) .* reshape(radii, 1, :))
+    RT = promote_type(eltype(k), typeof(float(real(zero(eltype(C))))))
+    out = zeros(RT, length(k))
+    for I in eachindex(C, ids)
+        id = ids[I]
+        c = real(C[I])
+        @inbounds for i in eachindex(k)
+            out[i] += weights[i, id] * c
+        end
+    end
+    @. out *= k * dx * dy / 2 / pi
+    return out
+end
+
+function _cached_sinc_reduce(k, x, y, z, C)
+    cache = _cached_radial_ids_3d(x, y, z)
+    isnothing(cache) && return nothing
+    ids, radii, dx, dy, dz = cache
+    weights = _sinc_times_pi.(reshape(k, :, 1) .* reshape(radii, 1, :))
+    RT = promote_type(eltype(k), typeof(float(real(zero(eltype(C))))))
+    out = zeros(RT, length(k))
+    for I in eachindex(C, ids)
+        id = ids[I]
+        c = real(C[I])
+        @inbounds for i in eachindex(k)
+            out[i] += weights[i, id] * c
+        end
+    end
+    @. out *= k^2 * dx * dy * dz / 2 / pi^2
+    return out
+end
+
 function sinc_reduce(k, x, y, z, C)
+    cached = _cached_sinc_reduce(k, x, y, z, C)
+    !isnothing(cached) && return cached
+
     dx, dy, dz = x[2] - x[1], y[2] - y[1], z[2] - z[1]
     Nx, Ny, Nz = 2 * length(x), 2 * length(y), 2 * length(z)
     Lx = x[end] - x[begin] + dx

--- a/src/checkpoint_analysis.jl
+++ b/src/checkpoint_analysis.jl
@@ -1,0 +1,46 @@
+struct CUDADevice end
+
+const _CUDA_LOAD_ERROR = "CUDA checkpoint analysis requires CUDA.jl to be loaded in the active environment"
+
+"""
+    gpu(psi::Psi)
+
+Move a `Psi` field and its coordinate vectors to CUDA device arrays.
+Requires CUDA.jl to be loaded and functional in the active environment.
+"""
+gpu(args...; kwargs...) = error(_CUDA_LOAD_ERROR)
+
+"""
+    cpu(psi::Psi)
+
+Move a `Psi` field and its coordinate vectors back to host `Array`s.
+Requires CUDA.jl to be loaded in the active environment.
+"""
+cpu(args...; kwargs...) = error(_CUDA_LOAD_ERROR)
+
+"""
+    checkpoint_analysis_cache(psi; backend=CUDADevice(), k=nothing, nradial=length(psi.K[1]))
+
+Construct reusable storage for CUDA checkpoint spectrum analysis. The CUDA extension
+currently supports 2D and 3D device-resident `Psi` fields and errors if CUDA is not
+available.
+"""
+function checkpoint_analysis_cache(args...; backend = CUDADevice(), kwargs...)
+    backend isa CUDADevice ||
+        error("Unsupported checkpoint analysis backend: $(typeof(backend))")
+    return error(_CUDA_LOAD_ERROR)
+end
+
+"""
+    analyze_checkpoint!(cache, psi; spectra=(:density, :kinetic))
+
+Update checkpoint spectra in `cache` for a device-resident `Psi`.
+"""
+analyze_checkpoint!(args...; kwargs...) = error(_CUDA_LOAD_ERROR)
+
+"""
+    checkpoint_results(cache; host=false)
+
+Return checkpoint spectra. With `host=true`, copy the result arrays back to the CPU.
+"""
+checkpoint_results(args...; kwargs...) = error(_CUDA_LOAD_ERROR)

--- a/test/test_internal_helpers.jl
+++ b/test/test_internal_helpers.jl
@@ -23,6 +23,40 @@
     @test QuantumFluidSpectra._integrated_bessel_reduce(k2r, X2[1], X2[2], zc2) ≈
           zeros(length(k2r))
 
+    p2 = collect(0:(size(zc2, 1)-1))
+    q2 = collect(0:(size(zc2, 2)-1))
+    c2 = @. complex(cos(2π * p2 / size(zc2, 1))) + 0.2im * sin(2π * q2' / size(zc2, 2))
+    ids2, radii2, dx2, _ = QuantumFluidSpectra._cached_radial_ids_2d(X2[1], X2[2])
+    @test minimum(ids2) == 1
+    @test maximum(ids2) == length(radii2)
+    cached_bessel_weights =
+        QuantumFluidSpectra.besselj0.(reshape(k2r, :, 1) .* reshape(radii2, 1, :))
+    ix2 = reshape(collect(0:(size(zc2, 1)-1)) .- size(zc2, 1) ÷ 2, :, 1)
+    iy2 = reshape(collect(0:(size(zc2, 2)-1)) .- size(zc2, 2) ÷ 2, 1, :)
+    full_radii2 = dx2 .* sqrt.(ix2 .^ 2 .+ iy2 .^ 2)
+    full_bessel_weights =
+        QuantumFluidSpectra.besselj0.(
+            reshape(k2r, :, 1, 1) .* reshape(full_radii2, 1, size(zc2)...),
+        )
+    lookup_bessel_weights = similar(full_bessel_weights)
+    for q in axes(ids2, 2), p in axes(ids2, 1), i in eachindex(k2r)
+        lookup_bessel_weights[i, p, q] = cached_bessel_weights[i, ids2[p, q]]
+    end
+    @test lookup_bessel_weights == full_bessel_weights
+
+    cached2 = QuantumFluidSpectra._cached_bessel_reduce(k2r, X2[1], X2[2], c2)
+    @test !isnothing(cached2)
+    @test cached2 ≈ QuantumFluidSpectra.bessel_reduce(k2r, X2[1], X2[2], c2)
+    @test isnothing(QuantumFluidSpectra._cached_bessel_reduce(k2r, 2 .* X2[1], X2[2], c2))
+    @test all(isfinite, QuantumFluidSpectra.bessel_reduce(k2r, 2 .* X2[1], X2[2], c2))
+    X2f = map(x -> Float32.(x), X2)
+    k2f = Float32.(k2r)
+    c2f = ComplexF32.(c2)
+    _, radii2f, _, _ = QuantumFluidSpectra._cached_radial_ids_2d(X2f[1], X2f[2])
+    @test eltype(radii2f) === Float32
+    @test eltype(QuantumFluidSpectra._cached_bessel_reduce(k2f, X2f[1], X2f[2], c2f)) ===
+          Float32
+
     V2(x, y, t) = 0.5 * (x^2 + y^2)
     trap2 = QuantumFluidSpectra._trap_field(psi2, V2, 0.0)
     rhs2 = QuantumFluidSpectra._gpe_rhs(psi2; g = 1.0, V = V2, t = 0.0)
@@ -63,6 +97,49 @@
           zeros(length(k3r))
     @test QuantumFluidSpectra._integrated_sinc_reduce(k3r, X3[1], X3[2], X3[3], zc3) ≈
           zeros(length(k3r))
+    p3 = collect(0:(size(zc3, 1)-1))
+    q3 = collect(0:(size(zc3, 2)-1))
+    r3 = collect(0:(size(zc3, 3)-1))
+    p3r = reshape(p3, :, 1, 1)
+    q3r = reshape(q3, 1, :, 1)
+    r3r = reshape(r3, 1, 1, :)
+    c3 = @. complex(cos(2π * p3r / size(zc3, 1))) +
+       0.2im * sin(2π * q3r / size(zc3, 2)) +
+       0.1 * cos(2π * r3r / size(zc3, 3))
+    ids3, radii3, dx3, _, _ = QuantumFluidSpectra._cached_radial_ids_3d(X3[1], X3[2], X3[3])
+    @test minimum(ids3) == 1
+    @test maximum(ids3) == length(radii3)
+    cached_sinc_weights =
+        QuantumFluidSpectra._sinc_times_pi.(reshape(k3r, :, 1) .* reshape(radii3, 1, :))
+    ix3 = reshape(collect(0:(size(zc3, 1)-1)) .- size(zc3, 1) ÷ 2, :, 1, 1)
+    iy3 = reshape(collect(0:(size(zc3, 2)-1)) .- size(zc3, 2) ÷ 2, 1, :, 1)
+    iz3 = reshape(collect(0:(size(zc3, 3)-1)) .- size(zc3, 3) ÷ 2, 1, 1, :)
+    full_radii3 = dx3 .* sqrt.(ix3 .^ 2 .+ iy3 .^ 2 .+ iz3 .^ 2)
+    full_sinc_weights =
+        QuantumFluidSpectra._sinc_times_pi.(
+            reshape(k3r, :, 1, 1, 1) .* reshape(full_radii3, 1, size(zc3)...),
+        )
+    lookup_sinc_weights = similar(full_sinc_weights)
+    for r in axes(ids3, 3), q in axes(ids3, 2), p in axes(ids3, 1), i in eachindex(k3r)
+        lookup_sinc_weights[i, p, q, r] = cached_sinc_weights[i, ids3[p, q, r]]
+    end
+    @test lookup_sinc_weights == full_sinc_weights
+
+    cached3 = QuantumFluidSpectra._cached_sinc_reduce(k3r, X3[1], X3[2], X3[3], c3)
+    @test !isnothing(cached3)
+    @test cached3 ≈ QuantumFluidSpectra.sinc_reduce(k3r, X3[1], X3[2], X3[3], c3)
+    @test isnothing(
+        QuantumFluidSpectra._cached_sinc_reduce(k3r, 2 .* X3[1], X3[2], X3[3], c3),
+    )
+    @test all(isfinite, QuantumFluidSpectra.sinc_reduce(k3r, 2 .* X3[1], X3[2], X3[3], c3))
+    X3f = map(x -> Float32.(x), X3)
+    k3f = Float32.(k3r)
+    c3f = ComplexF32.(c3)
+    _, radii3f, _, _, _ = QuantumFluidSpectra._cached_radial_ids_3d(X3f[1], X3f[2], X3f[3])
+    @test eltype(radii3f) === Float32
+    @test eltype(
+        QuantumFluidSpectra._cached_sinc_reduce(k3f, X3f[1], X3f[2], X3f[3], c3f),
+    ) === Float32
     @test QuantumFluidSpectra._sinc_times_pi(0.0) == 1.0
     @test QuantumFluidSpectra._sinc_times_pi(1e-3) ≈ sin(1e-3) / 1e-3
     @test QuantumFluidSpectra._integrated_sinc_kernel(2.0, 0.0) ≈ 8 / 3
@@ -85,4 +162,26 @@
     @test QuantumFluidSpectra._shell_area(psi3) == 4π
     @test QuantumFluidSpectra._integrated_gpe_prefactor(psi3) == 1 / π^2
     @test QuantumFluidSpectra._gradient_fields(psi3) == gradient(psi3)
+end
+
+@testset "Checkpoint CUDA stubs without CUDA.jl" begin
+    @test CUDADevice() isa CUDADevice
+    @test_throws ErrorException gpu("not a psi"; copy = false)
+    @test_throws ErrorException cpu("not a psi"; copy = false)
+    err = try
+        checkpoint_analysis_cache("not a psi"; nradial = 4)
+    catch err
+        err
+    end
+    @test err isa ErrorException
+    @test occursin("CUDA checkpoint analysis requires CUDA.jl", sprint(showerror, err))
+    err = try
+        checkpoint_analysis_cache("not a psi"; backend = :cpu)
+    catch err
+        err
+    end
+    @test err isa ErrorException
+    @test occursin("Unsupported checkpoint analysis backend", sprint(showerror, err))
+    @test_throws ErrorException analyze_checkpoint!(nothing, nothing; spectra = (:density,))
+    @test_throws ErrorException checkpoint_results(nothing; host = true)
 end


### PR DESCRIPTION
## Summary
- add CUDA.jl package extension entry points for device-resident checkpoint spectrum analysis
- add GPU/CPU `Psi` conversion helpers, strict CUDA availability/device checks, and cache-backed CUDA density/kinetic checkpoint spectra
- make cached radial lookup the default reduction path for CPU 2D Bessel and CPU 3D sinc spectra when grid spacing is isotropic, with the existing direct CPU path kept as fallback
- add device-resident radial lookup tables for CUDA 2D and 3D reductions so repeated wavefunction analyses reuse cached weights
- reuse cache-owned CUDA work arrays for padded/correlation buffers during checkpoint analysis
- keep the reusable CPU/GPU benchmark harness, but remove benchmark-time package environment mutation and one-off FGPE movie scripts
- cap CUDA compat below the CUDA 12-runtime line for Thunderbird CUDA 11.x driver compatibility

## Verification
- Local CPU suite: `julia --project=. -e 'using Pkg; Pkg.test()'` passed\n- JuliaFormatter check on changed Julia files: passed\n- Thunderbird25 CUDA smoke: `QuantumFluidSpectra` + CUDA 5.8.3 on NVIDIA TITAN V, 3D checkpoint cache with `nradial=12`, `analyze_checkpoint!` returned finite density and kinetic spectra `(12, 12, 12)`\n\n## Notes\n- The checkpoint API errors immediately if CUDA is requested without a functional CUDA.jl environment.\n- The CUDA reduction path keeps FFT inputs/work buffers, correlation arrays, radial lookup IDs/weights, partial reductions, and output spectra on device until `checkpoint_results(...; host=true)` is requested.\n