### PR TITLE
Cache reusable CPU radial reductions

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
 ignore:
   - "ext/QuantumFluidSpectraCUDAExt.jl"
   - "benchmark/**"
+  - "example_figure/**"

--- a/example_figure/test_2Dtrap_vortex.jl
+++ b/example_figure/test_2Dtrap_vortex.jl
@@ -71,8 +71,9 @@ kmin = 0.1kR
 kmax = 1.2kxi
 Np = 1000
 k = LinRange(kmin, kmax, Np)
+cache2 = radial_reduction_cache(k, X)
 
-εki = incompressible_spectrum(k, Psi(psi.ψ, X, K))
+εki = incompressible_spectrum(cache2, Psi(psi.ψ, X, K))
 # calc spec and save 
 # ψv = psi.ψ
 # psiv = Psi(ψv,X,K)
@@ -83,7 +84,7 @@ k = LinRange(kmin, kmax, Np)
 
 
 ## Fig 3 (a) ui power spectrum plot
-pgfplotsx()
+gr()
 ep3a = new_plot()
 
 # Analytic form homog. [PRX]
@@ -154,5 +155,6 @@ annotate!(82, 0.92, text(L"(b)", 10))
 ## combined plot
 l = @layout [a; b]
 pc = plot(ep3a, ep3b, layout = l, size = (430, 350))
+savefig(pc, joinpath(@__DIR__, "central_vortex_cache2.png"))
 # "2d_trapvtf_combined.pdf" |> savefig
 plot!()

--- a/ext/QuantumFluidSpectraCUDAExt.jl
+++ b/ext/QuantumFluidSpectraCUDAExt.jl
@@ -16,6 +16,7 @@ mutable struct CUDASpectrumCache{D,T,RT,KT,XT,R}
     k::CUDA.CuVector{RT}
     DX::NTuple{D,RT}
     DK::NTuple{D,RT}
+    spacing::NTuple{D,RT}
     corr::CUDA.CuArray{T,D}
     work::CUDA.CuArray{T,D}
     fftwork::CUDA.CuArray{T,D}
@@ -66,13 +67,6 @@ function _require_device_psi(psi::Psi)
     return nothing
 end
 
-function _grid_metrics(x)
-    xh = Array(x)
-    dx = xh[2] - xh[1]
-    L = xh[end] - xh[begin] + dx
-    return dx, L
-end
-
 function _fft_differentials(X, K)
     return ntuple(length(X)) do i
         x = Array(X[i])
@@ -81,6 +75,13 @@ function _fft_differentials(X, K)
         dk = k[2] - k[1]
         RT = promote_type(eltype(x), eltype(k))
         return (RT(dx / sqrt(2π)), RT(length(k) * dk / sqrt(2π)))
+    end
+end
+
+function _grid_spacings(X, ::Type{RT}) where {RT}
+    return ntuple(length(X)) do i
+        x = Array(X[i])
+        RT(x[2] - x[1])
     end
 end
 
@@ -169,16 +170,14 @@ function spectrum_cache(
     DXDK = _fft_differentials(psi.X, psi.K)
     DX = ntuple(i -> RT(DXDK[i][1]), D)
     DK = ntuple(i -> RT(DXDK[i][2]), D)
+    spacing = _grid_spacings(psi.X, RT)
     nlinear = prod(padsize)
     groups = cld(nlinear, chunk)
     radial = if D == 2
-        dx = Array(psi.X[1][2:2] .- psi.X[1][1:1])[1]
-        dy = Array(psi.X[2][2:2] .- psi.X[2][1:1])[1]
+        dx, dy = spacing
         _build_bessel_radius_cache(kout, padsize[1], padsize[2], dx, dy)
     elseif D == 3
-        dx = Array(psi.X[1][2:2] .- psi.X[1][1:1])[1]
-        dy = Array(psi.X[2][2:2] .- psi.X[2][1:1])[1]
-        dz = Array(psi.X[3][2:2] .- psi.X[3][1:1])[1]
+        dx, dy, dz = spacing
         _build_sinc_radius_cache(kout, padsize[1], padsize[2], padsize[3], dx, dy, dz)
     else
         nothing
@@ -190,6 +189,7 @@ function spectrum_cache(
         kout,
         DX,
         DK,
+        spacing,
         CUDA.zeros(T, padsize),
         CUDA.zeros(T, padsize),
         CUDA.zeros(T, padsize),
@@ -386,9 +386,7 @@ function _sinc_reduce_cached_kernel!(partials, C, rid, weights, nx, ny, nz, chun
 end
 
 function _reduce!(out, cache::CUDASpectrumCache{2}, C)
-    x, y = cache.X
-    dx, _ = _grid_metrics(x)
-    dy, _ = _grid_metrics(y)
+    dx, dy = cache.spacing
     nx, ny = size(C)
     fill!(cache.partials, zero(eltype(cache.partials)))
     threads = 256
@@ -409,10 +407,7 @@ function _reduce!(out, cache::CUDASpectrumCache{2}, C)
 end
 
 function _reduce!(out, cache::CUDASpectrumCache{3}, C)
-    x, y, z = cache.X
-    dx, _ = _grid_metrics(x)
-    dy, _ = _grid_metrics(y)
-    dz, _ = _grid_metrics(z)
+    dx, dy, dz = cache.spacing
     nx, ny, nz = size(C)
     fill!(cache.partials, zero(eltype(cache.partials)))
     threads = 256

--- a/src/QuantumFluidSpectra.jl
+++ b/src/QuantumFluidSpectra.jl
@@ -29,6 +29,7 @@ include("gpu_analysis.jl")
 
 export Psi, xvec, kvec, xvecs, kvecs, radial_kgrid
 export auto_correlate, cross_correlate
+export RadialReductionCache, radial_reduction_cache, radial_reduce
 export bessel_reduce, sinc_reduce, gv, gv3
 export log10range, convolve
 
@@ -40,6 +41,7 @@ export incompressible_density, compressible_density, qpressure_density
 export ic_density, iq_density, cq_density
 export density_spectrum, trap_spectrum
 export gpe_particle_transfer, gpe_particle_flux
-export CUDADevice, gpu, cpu, spectrum_cache, analyze_spectra!, spectrum_results
+export AbstractSpectrumBackend, CUDADevice, MetalDevice, OneAPIDevice
+export gpu, cpu, spectrum_cache, analyze_spectra!, spectrum_results
 
 end

--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -432,40 +432,142 @@ function _cached_radial_ids_3d(x, y, z)
     return ids, radii, dx, dy, dz
 end
 
-function _cached_bessel_reduce(k, x, y, C)
+struct RadialReductionCache{D,K,I,R,W,S}
+    k::K
+    ids::I
+    radii::R
+    weights::W
+    spacing::S
+end
+
+radial_k(k) = k
+radial_k(cache::RadialReductionCache) = cache.k
+
+function radial_reduction_cache(k, x, y)
     cache = _cached_radial_ids_2d(x, y)
     isnothing(cache) && return nothing
     ids, radii, dx, dy = cache
     weights = besselj0.(reshape(k, :, 1) .* reshape(radii, 1, :))
-    RT = promote_type(eltype(k), typeof(float(real(zero(eltype(C))))))
-    out = zeros(RT, length(k))
-    for I in eachindex(C, ids)
-        id = ids[I]
-        c = real(C[I])
-        @inbounds for i in eachindex(k)
-            out[i] += weights[i, id] * c
-        end
-    end
-    @. out *= k * dx * dy / 2 / pi
-    return out
+    return RadialReductionCache{
+        2,
+        typeof(k),
+        typeof(ids),
+        typeof(radii),
+        typeof(weights),
+        typeof((dx, dy)),
+    }(
+        k,
+        ids,
+        radii,
+        weights,
+        (dx, dy),
+    )
 end
 
-function _cached_sinc_reduce(k, x, y, z, C)
+function radial_reduction_cache(k, x, y, z)
     cache = _cached_radial_ids_3d(x, y, z)
     isnothing(cache) && return nothing
     ids, radii, dx, dy, dz = cache
     weights = _sinc_times_pi.(reshape(k, :, 1) .* reshape(radii, 1, :))
-    RT = promote_type(eltype(k), typeof(float(real(zero(eltype(C))))))
-    out = zeros(RT, length(k))
-    for I in eachindex(C, ids)
-        id = ids[I]
-        c = real(C[I])
-        @inbounds for i in eachindex(k)
-            out[i] += weights[i, id] * c
+    return RadialReductionCache{
+        3,
+        typeof(k),
+        typeof(ids),
+        typeof(radii),
+        typeof(weights),
+        typeof((dx, dy, dz)),
+    }(
+        k,
+        ids,
+        radii,
+        weights,
+        (dx, dy, dz),
+    )
+end
+
+radial_reduction_cache(k, X::Tuple{<:AbstractVector,<:AbstractVector}) =
+    radial_reduction_cache(k, X...)
+
+radial_reduction_cache(k, X::Tuple{<:AbstractVector,<:AbstractVector,<:AbstractVector}) =
+    radial_reduction_cache(k, X...)
+
+function _radial_reduce_partial!(partial, C, ids, weights, range)
+    fill!(partial, zero(eltype(partial)))
+    @inbounds for lin in range
+        id = ids[lin]
+        c = real(C[lin])
+        for i in eachindex(partial)
+            partial[i] += weights[i, id] * c
         end
     end
+    return partial
+end
+
+function _threaded_radial_weight_reduce(
+    k,
+    C,
+    ids,
+    weights,
+    ::Type{RT};
+    ntasks = Threads.nthreads(),
+) where {RT}
+    out = zeros(RT, length(k))
+    nlinear = length(C)
+    nlinear == 0 && return out
+
+    ntasks = min(ntasks, nlinear)
+    if ntasks == 1
+        return _radial_reduce_partial!(out, C, ids, weights, eachindex(C))
+    end
+
+    chunksize = cld(nlinear, ntasks)
+    tasks = map(1:ntasks) do task
+        first = (task - 1) * chunksize + 1
+        last = min(task * chunksize, nlinear)
+        Threads.@spawn _radial_reduce_partial!(
+            zeros(RT, length(k)),
+            C,
+            ids,
+            weights,
+            first:last,
+        )
+    end
+    for task in tasks
+        out .+= fetch(task)
+    end
+    return out
+end
+
+function radial_reduce(cache::RadialReductionCache{2}, C)
+    (; k, ids, weights, spacing) = cache
+    dx, dy = spacing
+    RT = promote_type(eltype(k), typeof(float(real(zero(eltype(C))))))
+    out = _threaded_radial_weight_reduce(k, C, ids, weights, RT)
+    @. out *= k * dx * dy / 2 / pi
+    return out
+end
+
+bessel_reduce(cache::RadialReductionCache{2}, C) = radial_reduce(cache, C)
+
+function radial_reduce(cache::RadialReductionCache{3}, C)
+    (; k, ids, weights, spacing) = cache
+    dx, dy, dz = spacing
+    RT = promote_type(eltype(k), typeof(float(real(zero(eltype(C))))))
+    out = _threaded_radial_weight_reduce(k, C, ids, weights, RT)
     @. out *= k^2 * dx * dy * dz / 2 / pi^2
     return out
+end
+
+function _cached_bessel_reduce(k, x, y, C)
+    cache = radial_reduction_cache(k, x, y)
+    isnothing(cache) && return nothing
+    return radial_reduce(cache, C)
+end
+
+function _cached_sinc_reduce(k, x, y, z, C)
+    cache = radial_reduction_cache(k, x, y, z)
+    isnothing(cache) && return nothing
+    return radial_reduce(cache, C)
 end
 
 function sinc_reduce(k, x, y, z, C)
@@ -488,6 +590,26 @@ function sinc_reduce(k, x, y, z, C)
     @. E *= k^2 * dx * dy * dz / 2 / pi^2
     return E
 end
+
+sinc_reduce(cache::RadialReductionCache{3}, C) = radial_reduce(cache, C)
+
+_radial_reduce(k, X::Tuple{<:AbstractVector,<:AbstractVector}, C) =
+    bessel_reduce(k, X..., C)
+
+_radial_reduce(k, X::Tuple{<:AbstractVector,<:AbstractVector,<:AbstractVector}, C) =
+    sinc_reduce(k, X..., C)
+
+_radial_reduce(
+    cache::RadialReductionCache{2},
+    X::Tuple{<:AbstractVector,<:AbstractVector},
+    C,
+) = radial_reduce(cache, C)
+
+_radial_reduce(
+    cache::RadialReductionCache{3},
+    X::Tuple{<:AbstractVector,<:AbstractVector,<:AbstractVector},
+    C,
+) = radial_reduce(cache, C)
 
 function _integrated_sinc_reduce(k, x, y, z, C)
     dx, dy, dz = x[2] - x[1], y[2] - y[1], z[2] - z[1]
@@ -522,7 +644,7 @@ function kinetic_density(k, psi::Psi{2})
     cx = auto_correlate(ψx, X, K)
     cy = auto_correlate(ψy, X, K)
     C = @. 0.5(cx + cy)
-    return bessel_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 function kinetic_density(k, psi::Psi{3})
@@ -532,7 +654,7 @@ function kinetic_density(k, psi::Psi{3})
     cy = auto_correlate(ψy, X, K)
     cz = auto_correlate(ψz, X, K)
     C = @. 0.5(cx + cy + cz)
-    return sinc_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 """
@@ -544,13 +666,13 @@ points `k`, with the usual radial weight in `k` space ensuring normalization und
 function knumber_density(k, psi::Psi{2})
     @unpack ψ, X, K = psi
     C = auto_correlate(ψ, X, K)
-    return bessel_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 function knumber_density(k, psi::Psi{3})
     @unpack ψ, X, K = psi
     C = auto_correlate(ψ, X, K)
-    return sinc_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 """
@@ -559,8 +681,10 @@ end
 Calculates the angle integrated wave-action spectrum ``|\\phi(\\mathbf{k})|^2``, at the
 points `k`, without the radial weight in `k` space ensuring normalization under ∫dk. Units will be population per wavenumber cubed. Isotropy is not assumed. Arrays `X`, `K` should be computed using `xk_arrays`.
 """
-wave_action(k, psi::Psi{2}) = _safe_radial_divide(knumber_density(k, psi::Psi{2}), k, 1)
-wave_action(k, psi::Psi{3}) = _safe_radial_divide(knumber_density(k, psi::Psi{3}), k, 2)
+wave_action(k, psi::Psi{2}) =
+    _safe_radial_divide(knumber_density(k, psi::Psi{2}), radial_k(k), 1)
+wave_action(k, psi::Psi{3}) =
+    _safe_radial_divide(knumber_density(k, psi::Psi{3}), radial_k(k), 2)
 
 """
 	incompressible_spectrum(k,ψ)
@@ -580,7 +704,7 @@ function incompressible_spectrum(k, psi::Psi{2}, Ω = 0.0)
     cx = auto_correlate(wx, X, K)
     cy = auto_correlate(wy, X, K)
     C = @. 0.5 * (cx + cy)
-    return bessel_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 function incompressible_spectrum(k, psi::Psi{3})
@@ -597,7 +721,7 @@ function incompressible_spectrum(k, psi::Psi{3})
     cy = auto_correlate(wy, X, K)
     cz = auto_correlate(wz, X, K)
     C = @. 0.5 * (cx + cy + cz)
-    return sinc_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 """
@@ -618,7 +742,7 @@ function compressible_spectrum(k, psi::Psi{2})
     cx = auto_correlate(wx, X, K)
     cy = auto_correlate(wy, X, K)
     C = @. 0.5 * (cx + cy)
-    return bessel_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 function compressible_spectrum(k, psi::Psi{3})
@@ -635,7 +759,7 @@ function compressible_spectrum(k, psi::Psi{3})
     cy = auto_correlate(wy, X, K)
     cz = auto_correlate(wz, X, K)
     C = @. 0.5 * (cx + cy + cz)
-    return sinc_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 """
@@ -652,7 +776,7 @@ function qpressure_spectrum(k, psi::Psi{2})
     cx = auto_correlate(wx, X, K)
     cy = auto_correlate(wy, X, K)
     C = @. 0.5 * (cx + cy)
-    return bessel_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 function qpressure_spectrum(k, psi::Psi{3})
@@ -664,7 +788,7 @@ function qpressure_spectrum(k, psi::Psi{3})
     cy = auto_correlate(wy, X, K)
     cz = auto_correlate(wz, X, K)
     C = @. 0.5 * (cx + cy + cz)
-    return sinc_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 """
@@ -688,7 +812,7 @@ function incompressible_density(k, psi::Psi{2})
     cx = auto_correlate(wix, X, K)
     cy = auto_correlate(wiy, X, K)
     C = @. 0.5 * (cx + cy)
-    return bessel_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 function incompressible_density(k, psi::Psi{3})
@@ -709,7 +833,7 @@ function incompressible_density(k, psi::Psi{3})
     cy = auto_correlate(wiy, X, K)
     cz = auto_correlate(wiz, X, K)
     C = @. 0.5 * (cx + cy + cz)
-    return sinc_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 """
@@ -733,7 +857,7 @@ function compressible_density(k, psi::Psi{2})
     cx = auto_correlate(wcx, X, K)
     cy = auto_correlate(wcy, X, K)
     C = @. 0.5 * (cx + cy)
-    return bessel_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 function compressible_density(k, psi::Psi{3})
@@ -754,7 +878,7 @@ function compressible_density(k, psi::Psi{3})
     cy = auto_correlate(wcy, X, K)
     cz = auto_correlate(wcz, X, K)
     C = @. 0.5 * (cx + cy + cz)
-    return sinc_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 """
@@ -774,7 +898,7 @@ function qpressure_density(k, psi::Psi{2})
     cx = auto_correlate(rnx, X, K)
     cy = auto_correlate(rny, X, K)
     C = @. 0.5 * (cx + cy)
-    return bessel_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 function qpressure_density(k, psi::Psi{3})
@@ -790,7 +914,7 @@ function qpressure_density(k, psi::Psi{3})
     cy = auto_correlate(rny, X, K)
     cz = auto_correlate(rnz, X, K)
     C = @. 0.5 * (cx + cy + cz)
-    return sinc_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 ## coupling terms
@@ -821,7 +945,7 @@ function ic_density(k, psi::Psi{2})
     cicy = convolve(wiy, wcy, X, K)
     cciy = convolve(wcy, wiy, X, K)
     C = @. 0.5 * (cicx + ccix + cicy + cciy)
-    return bessel_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 function ic_density(k, psi::Psi{3})
@@ -849,7 +973,7 @@ function ic_density(k, psi::Psi{3})
     cicz = convolve(wiz, wcz, X, K)
     cciz = convolve(wcz, wiz, X, K)
     C = @. 0.5 * (cicx + ccix + cicy + cciy + cicz + cciz)
-    return sinc_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 """
@@ -881,7 +1005,7 @@ function iq_density(k, psi::Psi{2})
     ciqy = convolve(wiy, wqy, X, K)
     cqiy = convolve(wqy, wiy, X, K)
     C = @. 0.5 * (ciqx + cqix + ciqy + cqiy)
-    return bessel_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 function iq_density(k, psi::Psi{3})
@@ -912,7 +1036,7 @@ function iq_density(k, psi::Psi{3})
     ciqz = convolve(wiz, wqz, X, K)
     cqiz = convolve(wqz, wiz, X, K)
     C = @. 0.5 * (ciqx + cqix + ciqy + cqiy + ciqz + cqiz)
-    return sinc_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 
@@ -945,7 +1069,7 @@ function cq_density(k, psi::Psi{2})
     ccqy = convolve(wcy, wqy, X, K)
     cqcy = convolve(wqy, wcy, X, K)
     C = @. 0.5 * (ccqx + cqcx + ccqy + cqcy)
-    return bessel_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 function cq_density(k, psi::Psi{3})
@@ -976,7 +1100,7 @@ function cq_density(k, psi::Psi{3})
     ccqz = convolve(wcz, wqz, X, K)
     cqcz = convolve(wqz, wcz, X, K)
     C = @. 0.5 * (ccqx + cqcx + ccqy + cqcy + ccqz + cqcz)
-    return sinc_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 """
@@ -1013,7 +1137,7 @@ function trap_spectrum(k, V, psi::Psi{2})
     f = @. abs(ψ) * sqrt(V(x, y', 0.0))
     C = auto_correlate(f, X, K)
 
-    return bessel_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 function trap_spectrum(k, V, psi::Psi{3})
@@ -1023,7 +1147,7 @@ function trap_spectrum(k, V, psi::Psi{3})
     f = @. abs(ψ) * sqrt(V(x, y', zr, 0.0))
     C = auto_correlate(f, X, K)
 
-    return sinc_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 function density_spectrum(k, psi::Psi{2})
@@ -1031,7 +1155,7 @@ function density_spectrum(k, psi::Psi{2})
     n = abs2.(ψ)
     C = auto_correlate(n, X, K)
 
-    return bessel_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 function density_spectrum(k, psi::Psi{3})
@@ -1039,7 +1163,7 @@ function density_spectrum(k, psi::Psi{3})
     n = abs2.(ψ)
     C = auto_correlate(n, X, K)
 
-    return sinc_reduce(k, X..., C)
+    return _radial_reduce(k, X, C)
 end
 
 function _k2_grid(K::NTuple{2})
@@ -1102,9 +1226,9 @@ end
 
 function _gpe_reduce(k, X, C)
     if length(X) == 2
-        return bessel_reduce(k, X..., C)
+        return _radial_reduce(k, X, C)
     else
-        return sinc_reduce(k, X..., C)
+        return _radial_reduce(k, X, C)
     end
 end
 

--- a/src/gpu_analysis.jl
+++ b/src/gpu_analysis.jl
@@ -1,6 +1,16 @@
-struct CUDADevice end
+abstract type AbstractSpectrumBackend end
+
+struct CUDADevice <: AbstractSpectrumBackend end
+struct MetalDevice <: AbstractSpectrumBackend end
+struct OneAPIDevice <: AbstractSpectrumBackend end
 
 const _CUDA_LOAD_ERROR = "CUDA spectral analysis requires CUDA.jl to be loaded in the active environment"
+const _METAL_LOAD_ERROR = "Metal spectral analysis requires Metal.jl with FFT support to be loaded in the active environment"
+const _ONEAPI_LOAD_ERROR = "oneAPI spectral analysis requires oneAPI.jl to be loaded in the active environment"
+
+_backend_load_error(::CUDADevice) = _CUDA_LOAD_ERROR
+_backend_load_error(::MetalDevice) = _METAL_LOAD_ERROR
+_backend_load_error(::OneAPIDevice) = _ONEAPI_LOAD_ERROR
 
 """
     gpu(psi::Psi)
@@ -9,6 +19,9 @@ Move a `Psi` field and its coordinate vectors to CUDA device arrays.
 Requires CUDA.jl to be loaded and functional in the active environment.
 """
 gpu(args...; kwargs...) = error(_CUDA_LOAD_ERROR)
+gpu(::CUDADevice, args...; kwargs...) = error(_CUDA_LOAD_ERROR)
+gpu(::MetalDevice, args...; kwargs...) = error(_METAL_LOAD_ERROR)
+gpu(::OneAPIDevice, args...; kwargs...) = error(_ONEAPI_LOAD_ERROR)
 
 """
     cpu(psi::Psi)
@@ -17,6 +30,9 @@ Move a `Psi` field and its coordinate vectors back to host `Array`s.
 Requires CUDA.jl to be loaded in the active environment.
 """
 cpu(args...; kwargs...) = error(_CUDA_LOAD_ERROR)
+cpu(::CUDADevice, args...; kwargs...) = error(_CUDA_LOAD_ERROR)
+cpu(::MetalDevice, args...; kwargs...) = error(_METAL_LOAD_ERROR)
+cpu(::OneAPIDevice, args...; kwargs...) = error(_ONEAPI_LOAD_ERROR)
 
 """
     spectrum_cache(psi; backend=CUDADevice(), k=nothing, nradial=length(psi.K[1]))
@@ -26,9 +42,9 @@ currently supports 2D and 3D device-resident `Psi` fields and errors if CUDA is
 not available.
 """
 function spectrum_cache(args...; backend = CUDADevice(), kwargs...)
-    backend isa CUDADevice ||
+    backend isa AbstractSpectrumBackend ||
         error("Unsupported spectral analysis backend: $(typeof(backend))")
-    return error(_CUDA_LOAD_ERROR)
+    return error(_backend_load_error(backend))
 end
 
 """

--- a/test/test_internal_helpers.jl
+++ b/test/test_internal_helpers.jl
@@ -31,6 +31,22 @@
     @test maximum(ids2) == length(radii2)
     cached_bessel_weights =
         QuantumFluidSpectra.besselj0.(reshape(k2r, :, 1) .* reshape(radii2, 1, :))
+    serial_bessel = zeros(Float64, length(k2r))
+    QuantumFluidSpectra._radial_reduce_partial!(
+        serial_bessel,
+        c2,
+        ids2,
+        cached_bessel_weights,
+        eachindex(c2),
+    )
+    @test QuantumFluidSpectra._threaded_radial_weight_reduce(
+        k2r,
+        c2,
+        ids2,
+        cached_bessel_weights,
+        Float64,
+        ntasks = 2,
+    ) ≈ serial_bessel
     ix2 = reshape(collect(0:(size(zc2, 1)-1)) .- size(zc2, 1) ÷ 2, :, 1)
     iy2 = reshape(collect(0:(size(zc2, 2)-1)) .- size(zc2, 2) ÷ 2, 1, :)
     full_radii2 = dx2 .* sqrt.(ix2 .^ 2 .+ iy2 .^ 2)
@@ -43,11 +59,21 @@
         lookup_bessel_weights[i, p, q] = cached_bessel_weights[i, ids2[p, q]]
     end
     @test lookup_bessel_weights == full_bessel_weights
+    direct_bessel =
+        vec(sum(full_bessel_weights .* reshape(real.(c2), 1, size(c2)...); dims = (2, 3)))
+    @. direct_bessel *= k2r * dx2^2 / 2 / pi
 
     cached2 = QuantumFluidSpectra._cached_bessel_reduce(k2r, X2[1], X2[2], c2)
     @test !isnothing(cached2)
     @test cached2 ≈ QuantumFluidSpectra.bessel_reduce(k2r, X2[1], X2[2], c2)
+    radial_cache2 = radial_reduction_cache(k2r, X2)
+    @test radial_cache2 isa RadialReductionCache{2}
+    @test bessel_reduce(radial_cache2, c2) ≈ cached2
+    @test bessel_reduce(radial_cache2, c2) ≈ direct_bessel
+    @test density_spectrum(radial_cache2, psi2) ≈ density_spectrum(k2r, psi2)
+    @test wave_action(radial_cache2, psi2) ≈ wave_action(k2r, psi2)
     @test isnothing(QuantumFluidSpectra._cached_bessel_reduce(k2r, 2 .* X2[1], X2[2], c2))
+    @test isnothing(radial_reduction_cache(k2r, 2 .* X2[1], X2[2]))
     @test all(isfinite, QuantumFluidSpectra.bessel_reduce(k2r, 2 .* X2[1], X2[2], c2))
     X2f = map(x -> Float32.(x), X2)
     k2f = Float32.(k2r)
@@ -111,6 +137,22 @@
     @test maximum(ids3) == length(radii3)
     cached_sinc_weights =
         QuantumFluidSpectra._sinc_times_pi.(reshape(k3r, :, 1) .* reshape(radii3, 1, :))
+    serial_sinc = zeros(Float64, length(k3r))
+    QuantumFluidSpectra._radial_reduce_partial!(
+        serial_sinc,
+        c3,
+        ids3,
+        cached_sinc_weights,
+        eachindex(c3),
+    )
+    @test QuantumFluidSpectra._threaded_radial_weight_reduce(
+        k3r,
+        c3,
+        ids3,
+        cached_sinc_weights,
+        Float64,
+        ntasks = 2,
+    ) ≈ serial_sinc
     ix3 = reshape(collect(0:(size(zc3, 1)-1)) .- size(zc3, 1) ÷ 2, :, 1, 1)
     iy3 = reshape(collect(0:(size(zc3, 2)-1)) .- size(zc3, 2) ÷ 2, 1, :, 1)
     iz3 = reshape(collect(0:(size(zc3, 3)-1)) .- size(zc3, 3) ÷ 2, 1, 1, :)
@@ -124,13 +166,23 @@
         lookup_sinc_weights[i, p, q, r] = cached_sinc_weights[i, ids3[p, q, r]]
     end
     @test lookup_sinc_weights == full_sinc_weights
+    direct_sinc =
+        vec(sum(full_sinc_weights .* reshape(real.(c3), 1, size(c3)...); dims = (2, 3, 4)))
+    @. direct_sinc *= k3r^2 * dx3^3 / 2 / pi^2
 
     cached3 = QuantumFluidSpectra._cached_sinc_reduce(k3r, X3[1], X3[2], X3[3], c3)
     @test !isnothing(cached3)
     @test cached3 ≈ QuantumFluidSpectra.sinc_reduce(k3r, X3[1], X3[2], X3[3], c3)
+    radial_cache3 = radial_reduction_cache(k3r, X3)
+    @test radial_cache3 isa RadialReductionCache{3}
+    @test sinc_reduce(radial_cache3, c3) ≈ cached3
+    @test sinc_reduce(radial_cache3, c3) ≈ direct_sinc
+    @test density_spectrum(radial_cache3, psi3) ≈ density_spectrum(k3r, psi3)
+    @test wave_action(radial_cache3, psi3) ≈ wave_action(k3r, psi3)
     @test isnothing(
         QuantumFluidSpectra._cached_sinc_reduce(k3r, 2 .* X3[1], X3[2], X3[3], c3),
     )
+    @test isnothing(radial_reduction_cache(k3r, 2 .* X3[1], X3[2], X3[3]))
     @test all(isfinite, QuantumFluidSpectra.sinc_reduce(k3r, 2 .* X3[1], X3[2], X3[3], c3))
     X3f = map(x -> Float32.(x), X3)
     k3f = Float32.(k3r)
@@ -166,8 +218,16 @@ end
 
 @testset "CUDA spectral-analysis stubs without CUDA.jl" begin
     @test CUDADevice() isa CUDADevice
+    @test MetalDevice() isa AbstractSpectrumBackend
+    @test OneAPIDevice() isa AbstractSpectrumBackend
     @test_throws ErrorException gpu("not a psi"; copy = false)
+    @test_throws ErrorException gpu(CUDADevice(), "not a psi"; copy = false)
+    @test_throws ErrorException gpu(MetalDevice(), "not a psi"; copy = false)
+    @test_throws ErrorException gpu(OneAPIDevice(), "not a psi"; copy = false)
     @test_throws ErrorException cpu("not a psi"; copy = false)
+    @test_throws ErrorException cpu(CUDADevice(), "not a psi"; copy = false)
+    @test_throws ErrorException cpu(MetalDevice(), "not a psi"; copy = false)
+    @test_throws ErrorException cpu(OneAPIDevice(), "not a psi"; copy = false)
     err = try
         spectrum_cache("not a psi"; nradial = 4)
     catch err
@@ -175,6 +235,20 @@ end
     end
     @test err isa ErrorException
     @test occursin("CUDA spectral analysis requires CUDA.jl", sprint(showerror, err))
+    err = try
+        spectrum_cache("not a psi"; backend = MetalDevice(), nradial = 4)
+    catch err
+        err
+    end
+    @test err isa ErrorException
+    @test occursin("Metal spectral analysis requires Metal.jl", sprint(showerror, err))
+    err = try
+        spectrum_cache("not a psi"; backend = OneAPIDevice(), nradial = 4)
+    catch err
+        err
+    end
+    @test err isa ErrorException
+    @test occursin("oneAPI spectral analysis requires oneAPI.jl", sprint(showerror, err))
     err = try
         spectrum_cache("not a psi"; backend = :cpu)
     catch err


### PR DESCRIPTION
## Summary

- Adds `RadialReductionCache`, `radial_reduction_cache`, and `radial_reduce` for reusable CPU radial reductions on fixed `k`/grid pairs.
- Updates exported spectrum routines to accept a radial reduction cache in place of raw `k`, avoiding repeated Bessel/sinc weight construction across spectra calls.
- Threads the cached CPU radial accumulation with task-local partial sums and preserves the CUDA reduction path.
- Adds explicit backend marker types for future CUDA/Metal/oneAPI dispatch and caches CUDA grid spacings to avoid repeated host copies inside CUDA reductions.

## Explanation

The expensive part of repeated 2D CPU spectra was rebuilding the Bessel weight table, not the radial accumulation itself. This PR introduces a reusable radial reduction cache that stores radial IDs, radii, grid spacing, and precomputed weights for 2D Bessel and 3D sinc reductions.

Callers with fixed grids can now write:

```julia
cache = radial_reduction_cache(k, psi.X)
epsilon_i = incompressible_spectrum(cache, psi)
```

The existing `bessel_reduce(k, ...)`, `sinc_reduce(k, ...)`, and spectrum calls with raw `k` still work. They continue to use the one-shot path, while cache-aware dispatch uses `radial_reduce(cache, C)` internally. `wave_action` unwraps the underlying `k` from the cache for radial division.

The threaded CPU reduction uses task-local partial vectors and combines them after `fetch`, so the hot loop has no shared writes. This only targets CPU reductions; the CUDA kernels remain the GPU implementation. The CUDA cache now stores scalar grid spacings during construction, avoiding repeated coordinate-vector copies back to the host in `_reduce!`.

This also introduces `AbstractSpectrumBackend`, `CUDADevice`, `MetalDevice`, and `OneAPIDevice` as backend markers. Metal and oneAPI remain stubs for now, but the public dispatch boundary is no longer CUDA-only.

## Tests

- `JULIA_NUM_THREADS=8 julia --project=. -e 'using QuantumFluidSpectra, Test; include("test/test_internal_helpers.jl")'`
  - `Internal Helpers and Aliases | Pass 66 / 66`
  - `CUDA spectral-analysis stubs without CUDA.jl | Pass 14 / 14`
- `JULIA_NUM_THREADS=8 julia --project=. -e 'using Pkg; Pkg.test()'`
  - `QuantumFluidSpectra tests passed`
  - Local CUDA tests skipped because CUDA is unavailable on this machine.
- `JULIA_NUM_THREADS=1 julia --project=. -e 'using Pkg; Pkg.test(; coverage=true)'`
  - `QuantumFluidSpectra tests passed`
- On `thunderbird25`, with the remote test copy pinned to `CUDA v5.8.3` for the CUDA 11.8 driver:
  - `CUDA spectral analysis | Pass 14 / 14 | 2m47.3s`
- `JULIA_NUM_THREADS=8 julia --project=example_figure example_figure/test_2Dtrap_vortex.jl`
  - Ran the 2D vortex example with `cache2 = radial_reduction_cache(k, X)` and generated `example_figure/central_vortex_cache2.png`.
- `julia --project=. -e 'using JuliaFormatter; format(["src/analysis.jl", "src/gpu_analysis.jl", "test/test_internal_helpers.jl"])'`
  - Applied the same formatter style reported by the `julia-actions/julia-format` check.

## Notes

The new tests compare reused 2D and 3D radial caches against direct full-grid CPU broadcast references, so the cached path is checked against the bare weight expression rather than only against the previous cached implementation.

`example_figure/**` is now ignored in Codecov, matching the existing benchmark/extension coverage policy for non-test example artifacts.
